### PR TITLE
Ability to pass keyword args to CastingMixin casters

### DIFF
--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -253,6 +253,21 @@ class ValueTests(TestCase):
                     'USER': None,
                 }})
 
+    def test_database_url_additional_args(self):
+
+        def mock_database_url_caster(self, url, engine=None):
+            return { 'URL': url, 'ENGINE': engine }
+
+        with patch('configurations.values.DatabaseURLValue.caster', mock_database_url_caster):
+            value = DatabaseURLValue(engine='django_mysqlpool.backends.mysqlpool')
+            with env(DATABASE_URL='sqlite://'):
+                self.assertEqual(value.setup('DATABASE_URL'), {
+                    'default': {
+                        'URL': 'sqlite://',
+                        'ENGINE': 'django_mysqlpool.backends.mysqlpool'
+                    }
+                })
+
     def test_email_url_value(self):
         value = EmailURLValue()
         self.assertEqual(value.default, {})


### PR DESCRIPTION
I thought it would be nice to be able to pass additional arguments to casters.

Specific example would be an ability to set custom database engine in dj-database-url:
https://github.com/kennethreitz/dj-database-url/pull/26