### PR TITLE
Fixed wrong behaviour when assigning BooleanValue

### DIFF
--- a/configurations/values.py
+++ b/configurations/values.py
@@ -44,7 +44,7 @@ class Value(object):
     def __new__(cls, *args, **kwargs):
         """
         checks if the creation can end up directly in the final value.
-        That is the case whenever environ = False or environ_name is given
+        That is the case whenever environ = False or environ_name is given.
         """
         instance = object.__new__(cls)
         instance.__init__(*args, **kwargs)
@@ -59,7 +59,7 @@ class Value(object):
                  environ_prefix='DJANGO', *args, **kwargs):
         if 'late_binding' in kwargs:
             self.late_binding = kwargs.get('late_binding')
-        if isinstance(default, Value) and default.default:
+        if isinstance(default, Value) and default.default is not None:
             self.default = copy.copy(default.default)
         else:
             self.default = default

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -108,6 +108,12 @@ class ValueTests(TestCase):
         with env(DJANGO_TEST='nonboolean'):
             self.assertRaises(ValueError, value.setup, 'TEST')
 
+    def test_boolean_values_assign_false_to_another_booleanvalue(self):
+        value1 = BooleanValue(False)
+        value2 = BooleanValue(value1)
+        self.assertFalse(value1.setup('TEST1'))
+        self.assertFalse(value2.setup('TEST2'))
+
     def test_integer_values(self):
         value = IntegerValue(1)
         with env(DJANGO_TEST='2'):


### PR DESCRIPTION
When assigning False to a BooleanValue and reusing it was raising a
ValueError exception because BooleanValue was evaluating False as None.

Thanks to @abbottc for catching this error.