### PR TITLE
Remove coverage env from `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ skipsdist = True
 usedevelop = True
 minversion = 1.8
 envlist =
-    coverage-py27-dj16,
     flake8-py27,
     flake8-py33,
     py{26,py}-dj{14,15,16},


### PR DESCRIPTION
This commit extends `Remove coverage env from travis config` f1f997354798acb5eb330280b656530d62aec0dd