### PR TITLE
Use CommandParser instead of LaxOptionParser in django1.8 

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -2,12 +2,12 @@ import imp
 import logging
 import os
 import sys
-from optparse import make_option
 
+from django import VERSION as DJ_VERSION
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import ENVIRONMENT_VARIABLE as SETTINGS_ENVIRONMENT_VARIABLE
 
-from .utils import uppercase_attributes, reraise, LaxOptionParser
+from .utils import uppercase_attributes, reraise
 from .values import Value, setup_value
 
 installed = False
@@ -15,22 +15,9 @@ installed = False
 CONFIGURATION_ENVIRONMENT_VARIABLE = 'DJANGO_CONFIGURATION'
 
 
-configuration_options = (
-    make_option('--configuration',
-                help='The name of the configuration class to load, e.g. '
-                     '"Development". If this isn\'t provided, the '
-                     'DJANGO_CONFIGURATION environment variable will '
-                     'be used.'),)
-
-
 def install(check_options=False):
     global installed
     if not installed:
-        from django.core.management import base
-
-        # add the configuration option to all management commands
-        base.BaseCommand.option_list += configuration_options
-
         importer = ConfigurationImporter(check_options=check_options)
         sys.meta_path.insert(0, importer)
         installed = True
@@ -67,14 +54,48 @@ class ConfigurationImporter(object):
         return os.environ.get(self.namevar)
 
     def check_options(self):
-        parser = LaxOptionParser(option_list=configuration_options,
-                                 add_help_option=False)
-        try:
-            options, args = parser.parse_args(self.argv)
-            if options.configuration:
-                os.environ[self.namevar] = options.configuration
-        except:
-            pass  # Ignore any option errors at this point.
+        # django switched to argparse in version 1.8
+        if DJ_VERSION >= (1, 8):
+            from django.core.management.base import (CommandError,
+                                                     CommandParser,
+                                                     handle_default_options)
+            parser = CommandParser(None,
+                                   usage="%(prog)s subcommand [options] [args]",
+                                   add_help=False)
+            parser.add_argument('--settings')
+            parser.add_argument('--pythonpath')
+            parser.add_argument('--configuration',
+                                help='The name of the configuration class to load, e.g. '
+                                     '"Development". If this isn\'t provided, the '
+                                     'DJANGO_CONFIGURATION environment variable will '
+                                     'be used.')
+
+            parser.add_argument('args', nargs='*')  # catch-all
+            try:
+                options, args = parser.parse_known_args(self.argv[2:])
+                if options.configuration:
+                    os.environ[self.namevar] = options.configuration
+                handle_default_options(options)
+            except CommandError:
+                pass  # Ignore any option errors at this point.
+        # django < 1.7 did use optparse
+        else:
+            from django.core.management import LaxOptionParser
+            from optparse import make_option
+            configuration_options = (make_option('--configuration',
+                                                 help='The name of the configuration class to load, e.g. '
+                                                 '"Development". If this isn\'t provided, the '
+                                                 'DJANGO_CONFIGURATION environment variable will '
+                                                 'be used.'),)
+
+            parser = LaxOptionParser(option_list=configuration_options,
+                                     add_help_option=False)
+            try:
+                options, args = parser.parse_args(self.argv)
+                if options.configuration:
+                    os.environ[self.namevar] = options.configuration
+            except:
+                pass  # Ignore any option errors at this point.
 
     def validate(self):
         if self.name is None:

--- a/configurations/utils.py
+++ b/configurations/utils.py
@@ -62,68 +62,6 @@ def reraise(exc, prefix=None, suffix=None):
     exc.args = ('{0} {1} {2}'.format(prefix, exc.args[0], suffix),) + args[1:]
     raise
 
-try:
-    from django.core.management import LaxOptionParser
-except ImportError:
-    from optparse import OptionParser
-
-    class LaxOptionParser(OptionParser):
-        """
-        An option parser that doesn't raise any errors on unknown options.
-
-        This is needed because the --settings and --pythonpath options affect
-        the commands (and thus the options) that are available to the user.
-
-        Backported from Django 1.7.x
-
-        """
-        def error(self, msg):
-            pass
-
-        def print_help(self):
-            """Output nothing.
-
-            The lax options are included in the normal option parser, so under
-            normal usage, we don't need to print the lax options.
-            """
-            pass
-
-        def print_lax_help(self):
-            """Output the basic options available to every command.
-
-            This just redirects to the default print_help() behavior.
-            """
-            OptionParser.print_help(self)
-
-        def _process_args(self, largs, rargs, values):
-            """
-            Overrides OptionParser._process_args to exclusively handle default
-            options and ignore args and other options.
-
-            This overrides the behavior of the super class, which stop parsing
-            at the first unrecognized option.
-            """
-            while rargs:
-                arg = rargs[0]
-                try:
-                    if arg[0:2] == "--" and len(arg) > 2:
-                        # process a single long option (possibly with value(s))
-                        # the superclass code pops the arg off rargs
-                        self._process_long_opt(rargs, values)
-                    elif arg[:1] == "-" and len(arg) > 1:
-                        # process a cluster of short options (possibly with
-                        # value(s) for the last one only)
-                        # the superclass code pops the arg off rargs
-                        self._process_short_opts(rargs, values)
-                    else:
-                        # it's either a non-default option or an arg
-                        # either way, add it to the args list so we can keep
-                        # dealing with options
-                        del rargs[0]
-                        raise Exception
-                except:  # Needed because we might need to catch a SystemExit
-                    largs.append(arg)
-
 
 # Copied over from Sphinx
 if sys.version_info >= (3, 0):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+import os
+import subprocess
+
+PROJECT_DIR = os.getcwd()
+TEST_PROJECT_DIR = os.path.join(PROJECT_DIR, 'test_project')
+
+
+def test_configuration_argument_in_cli():
+    """Verify that's configuration option has been added to managements commands"""
+    os.chdir(TEST_PROJECT_DIR)
+    p = subprocess.Popen(['python', 'manage.py', 'test',
+                          '--help'], stdout=subprocess.PIPE)
+    assert '--configuration' in p.communicate()[0].decode('UTF-8')
+    p = subprocess.Popen(['python', 'manage.py', 'runserver',
+                          '--help'], stdout=subprocess.PIPE)
+    assert '--configuration' in p.communicate()[0].decode('UTF-8')
+    os.chdir(PROJECT_DIR)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,8 @@ deps =
     dj15: https://github.com/django/django/archive/stable/1.5.x.zip#egg=django
     dj16: https://github.com/django/django/archive/stable/1.6.x.zip#egg=django
     dj17: https://github.com/django/django/archive/stable/1.7.x.zip#egg=django
-    dj18: https://github.com/django/django/archive/master.zip#egg=django
+    dj18: https://github.com/django/django/archive/stable/1.8.x.zip#egg=django
+    dj19: https://github.com/django/django/archive/master.zip#egg=django
 
 commands =
     py.test {posargs:}


### PR DESCRIPTION
@jezdez I added a django version check to use `CommandParser` instead of `LaxOptionParser` if django>=1.8. I've tested it locally, this commit closes #65. django-configurations and pytest-django tests succeed.