### PR TITLE
Override env variables for tests

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,8 +3,8 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings.main')
-    os.environ.setdefault('DJANGO_CONFIGURATION', 'Test')
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings.main'
+    os.environ['DJANGO_CONFIGURATION'] = 'Test'
 
     from configurations.management import execute_from_command_line
 


### PR DESCRIPTION
If the user already have set this env variables to other values, this do not override the values and tests fails.