### PR TITLE
add entrypoints to run in non-source-tree installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
     author='Jannis Leidel',
     author_email='jannis@leidel.info',
     packages=['configurations'],
+    entry_points={
+	'console_scripts': [
+            'django-cadmin = configurations.management:execute_from_command_line',
+        ],
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',


### PR DESCRIPTION
this helps when deploying configurations where the app is deployed as bdist_wheel