### PR TITLE
print module name in all cases

### DIFF
--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -172,7 +172,7 @@ class ConfigurationLoader(object):
         except AttributeError as err:  # pragma: no cover
             reraise(err, "Couldn't find configuration '{0}' "
                          "in module '{1}'".format(self.name,
-                                                  mod.__name__)))
+                                                  mod.__name__))
         try:
             cls.pre_setup()
             cls.setup()

--- a/configurations/importer.py
+++ b/configurations/importer.py
@@ -172,7 +172,7 @@ class ConfigurationLoader(object):
         except AttributeError as err:  # pragma: no cover
             reraise(err, "Couldn't find configuration '{0}' "
                          "in module '{1}'".format(self.name,
-                                                  mod.__package__))
+                                                  mod.__name__)))
         try:
             cls.pre_setup()
             cls.setup()


### PR DESCRIPTION
mod.__package__ may be None, so always go for mod.__name__